### PR TITLE
Rename package to performance-api

### DIFF
--- a/.changeset/odd-panthers-applaud.md
+++ b/.changeset/odd-panthers-applaud.md
@@ -1,0 +1,5 @@
+---
+"performance-api": major
+---
+
+Rename package to performance-api

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# performance-ponyfill
+# performance-api
 
 ## 1.0.0
 ### Major Changes

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# performance-ponyfill
+# performance-api
 
 Cross platform access to the browser [performance API][1] which is
 needed for implementing accurate convergences and deadlines.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare module "performance-ponyfill" {
+declare module "performance-api" {
   var performance: Performance;
 
   var PerformanceObserver: {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "performance-ponyfill",
-  "version": "1.0.0",
+  "name": "performance-api",
+  "version": "0.0.0",
   "description": "Cross platform interface to the DOM performance API",
   "main": "node-ponyfill.js",
   "browser": "browser-ponyfill.js",
   "types": "index.d.ts",
-  "repository": "https://github.com/thefrontside/performance-ponyfill.git",
+  "repository": "https://github.com/thefrontside/performance-api.git",
   "author": "Frontside Engineering <engineering@frontside.com>",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
`performance-ponyfill` was taken (but not published from `bigtest` repo).