### PR TITLE
Update preview action source

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.event.pull_request.labels.*.name, 'preview')
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - uses: actions/setup-node@v2
       with:
         registry-url: https://registry.npmjs.org
     - name: Publish PR Preview
-      uses: thefrontside/actions/publish-pr-preview@main
+      uses: thefrontside/actions/publish-pr-preview@v2
       with:
         INSTALL_SCRIPT: yarn install && yarn prepack
       env:


### PR DESCRIPTION
## Motivation

This is part of an effort to finalize [@thefrontside/actions #68](https://github.com/thefrontside/actions/issues/68) by moving all actions being called from the `main` branch to move over to `v2`.

## Approach

- Updated action source
- Checkout needed to be upgraded to `v3` too due to [@thefrontside/actions #73](https://github.com/thefrontside/actions/pull/73)